### PR TITLE
Fix Add warning setup doesnot work in windows. #12 and minor Bug Fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def clear():
 	system("clear")
 
 def pause():
-	input("\n\nPress enter to continue...")
+	x=input("\n\nPress enter to continue...")
 	clear()
 		
 def install(url):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 import os
+import platform
 
+if platform.system().lower()=='windows':
+	print('Setup Doesnot Support Windows . \nPlease run " py main.py" at command prompt or powershell to run Git-manager...')
+	x=input('\nPress any key to continue...')
+	exit(0)
+	
 cwd = os.getcwd() 
 alias="\nalias git-manager='python {}/main.py'".format(cwd)
 


### PR DESCRIPTION
This patch will fix issue titled "Add warning setup doesnot work in windows. #12" and fixes syntax error reached eol while scanning string literal.